### PR TITLE
bump windows runner to version 2025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2025]
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This updates the windows runner from Windows Server 2019 to Windows Server 2025 and thereby skips the available Windows Server 2022. Windows Server 2019 has been retired.