### PR TITLE
Suppress superfluous multi-rule per checker warnings

### DIFF
--- a/qc_ositrace/main.py
+++ b/qc_ositrace/main.py
@@ -10,6 +10,9 @@ from qc_ositrace.checks.deserialization import deserialization_checker
 from qc_ositrace.checks.osirules import osirules_checker
 
 logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
+logging.getLogger().addFilter(
+    lambda record: "A check should address exactly one rule" not in record.getMessage()
+)
 
 
 def args_entrypoint() -> argparse.Namespace:


### PR DESCRIPTION
This warning by baselib is intrusive and currently makes no sense for OSI-rules based checks due to the high number of rules to be checked.